### PR TITLE
Switch to upstream pip install

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -17,7 +17,6 @@ RUN set -x \
         curl \
         git \
         libapache2-mod-wsgi \
-        virtualenv \
     && TOKEN=$(curl -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPO}:pull" | \
             python -c "import sys, json; print json.load(sys.stdin)['token']") \
     && BLOB=$(curl -sSL -H "Authorization: Bearer ${TOKEN}" https://registry.hub.docker.com/v2/${REPO}/manifests/${TAG} | \
@@ -30,15 +29,17 @@ RUN set -x \
        fi \
     && mkdir /tmp/packages \
     && tar xf /tmp/wheels.tar.gz -C /tmp/packages/ --strip-components=2 root/packages \
+    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python get-pip.py \
+    && rm get-pip.py \
+    && pip install virtualenv \
     && virtualenv /virtualenv \
     && hash -r \
-    && pip install --no-compile --upgrade pip setuptools \
     && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt /tmp/${PROJECT} \
     && apt-get purge -y --auto-remove \
         ca-certificates \
         curl \
         git \
-        virtualenv \
     && rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache \
     && find / -type f \( -name "*.pyc" -o -name "pip" -o -name "easy_install" -o -name "wheel" \) -delete \
     && groupadd -g 42424 ${PROJECT} && useradd -u 42424 -g ${PROJECT} -s /sbin/nologin -c "${PROJECT} user" ${PROJECT} \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -17,7 +17,6 @@ RUN set -x \
         curl \
         git \
         libapache2-mod-wsgi \
-        virtualenv \
     && TOKEN=$(curl -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPO}:pull" | \
             python -c "import sys, json; print json.load(sys.stdin)['token']") \
     && BLOB=$(curl -sSL -H "Authorization: Bearer ${TOKEN}" https://registry.hub.docker.com/v2/${REPO}/manifests/${TAG} | \
@@ -30,15 +29,17 @@ RUN set -x \
        fi \
     && mkdir /tmp/packages \
     && tar xf /tmp/wheels.tar.gz -C /tmp/packages/ --strip-components=2 root/packages \
+    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python get-pip.py \
+    && rm get-pip.py \
+    && pip install virtualenv \
     && virtualenv /virtualenv \
     && hash -r \
-    && pip install --no-compile --upgrade pip setuptools \
     && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt /tmp/${PROJECT} \
     && apt-get purge -y --auto-remove \
         ca-certificates \
         curl \
         git \
-        virtualenv \
     && rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache \
     && find / -type f \( -name "*.pyc" -o -name "pip" -o -name "easy_install" -o -name "wheel" \) -delete \
     && groupadd -g 42424 ${PROJECT} && useradd -u 42424 -g ${PROJECT} -s /sbin/nologin -c "${PROJECT} user" ${PROJECT} \


### PR DESCRIPTION
Installing the virtualenv package pulls in python3 deps that we don't
use. This takes additional time and then gets purged anyway. Install pip
from upstream and then install virtualenv is a bit cleaner and more
portable as well.