### PR TITLE
Add uwsgi

### DIFF
--- a/dockerfiles/Dockerfile-centos
+++ b/dockerfiles/Dockerfile-centos
@@ -48,7 +48,10 @@ RUN set -x \
     && chown ${PROJECT}:${PROJECT} /etc/${PROJECT} /var/log/${PROJECT} /var/lib/${PROJECT} /var/cache/${PROJECT} \
 # common install end
 # Project specific command block start
-    && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt python-memcached pymysql \
+    && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt \
+        pymysql \
+        python-memcached \
+        uwsgi \
     && sed -i 's/^Listen 80/#Listen 80/' /etc/httpd/conf/httpd.conf \
     && rm /etc/httpd/conf.d/* \
     && cp /virtualenv/bin/keystone-wsgi-* /usr/bin/ \

--- a/dockerfiles/Dockerfile-debian
+++ b/dockerfiles/Dockerfile-debian
@@ -47,7 +47,10 @@ RUN set -x \
     && chown ${PROJECT}:${PROJECT} /etc/${PROJECT} /var/log/${PROJECT} /var/lib/${PROJECT} /var/cache/${PROJECT} \
 # common install end
 # Project specific command block start
-    && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt python-memcached pymysql \
+    && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt \
+        pymysql \
+        python-memcached \
+        uwsgi \
     && rm /etc/apache2/ports.conf /etc/apache2/sites-enabled/* /etc/apache2/sites-available/* \
     && cp /virtualenv/bin/keystone-wsgi-* /usr/bin/ \
 # Provide compatibility with older format keystone apache config:

--- a/dockerfiles/Dockerfile-ubuntu
+++ b/dockerfiles/Dockerfile-ubuntu
@@ -47,7 +47,10 @@ RUN set -x \
     && chown ${PROJECT}:${PROJECT} /etc/${PROJECT} /var/log/${PROJECT} /var/lib/${PROJECT} /var/cache/${PROJECT} \
 # common install end
 # Project specific command block start
-    && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt python-memcached pymysql \
+    && pip install --no-index --no-compile --find-links /tmp/packages --constraint /tmp/packages/upper-constraints.txt \
+        pymysql \
+        python-memcached \
+        uwsgi \
     && rm /etc/apache2/ports.conf /etc/apache2/sites-enabled/* /etc/apache2/sites-available/* \
     && cp /virtualenv/bin/keystone-wsgi-* /usr/bin/ \
 # Provide compatibility with older format keystone apache config:


### PR DESCRIPTION
uwsgi is the recommended process for running keystone. It does not
support federation though. We can include both apache2 and uwsgi at
little extra cost